### PR TITLE
feature/delete-command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Laravel package to automatically create a og image that the page generates when 
 <!-- toc -->
 - [Installation](#installation)
 - [Configuration](#configuration)
+- [Delete Old Images](#delete-old-images)
 - [Testing](#testing)
 - [Credits](#credits)
 - [License](#license)
@@ -44,6 +45,18 @@ But you can configure the package by publishing the config file, which will allo
 - Image mime type - default is png
 - Storage disk - default is local
 - Storage path - default is public/og-images
+
+## Delete Old Images
+
+There is a command that you can run to delete all the old images that have been created by the package.
+
+```bash
+php artisan og-image:delete-old-images
+```
+
+This command will delete all the images that are older than 90 days.
+
+This command is added to the Laravel scheduler to run every day.
 
 ## Testing
 ```bash

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,6 @@
     },
     "scripts": {
         "post-autoload-dump": [
-            "@clear",
             "@prepare"
         ],
         "clear": "@php vendor/bin/testbench package:purge-skeleton --ansi",
@@ -65,6 +64,10 @@
         ],
         "test": [
             "./vendor/bin/pest"
+        ],
+        "lint": [
+            "@php vendor/bin/pint --ansi",
+            "@php vendor/bin/phpstan analyse --verbose --ansi"
         ]
     },
     "minimum-stability": "dev",

--- a/config/og-image-generator.php
+++ b/config/og-image-generator.php
@@ -14,6 +14,7 @@ return [
     'storage' => [
         'disk' => 'local',
         'path' => 'public/og-images',
+        'lifetime' => 90,
     ],
 
     /**

--- a/src/Console/Commands/DeleteOldImages.php
+++ b/src/Console/Commands/DeleteOldImages.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Paulund\OgImageGenerator\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Container\Attributes\Config;
+use Illuminate\Support\Facades\Storage;
+
+class DeleteOldImages extends Command
+{
+    protected $signature = 'og-image:delete-old-images';
+
+    protected $description = 'Delete old images from the storage folder';
+
+    public function __construct(
+        #[Config('og-image-generator.storage.disk')] private readonly string $disk,
+        #[Config('og-image-generator.storage.path')] private readonly string $path,
+        #[Config('og-image-generator.storage.lifetime')] private readonly string $lifetime,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): void
+    {
+        $this->info('Deleting old images...');
+
+        $files = Storage::disk($this->disk)->files($this->path);
+
+        $now = now();
+        foreach ($files as $file) {
+            $lastModified = Storage::disk($this->disk)->lastModified($file);
+            $fileDate = \Carbon\Carbon::createFromTimestamp($lastModified);
+
+            if (abs($now->diffInDays($fileDate)) > $this->lifetime) {
+                Storage::disk($this->disk)->delete($file);
+                $this->info("Deleted: $file");
+            }
+        }
+
+        $this->info('Old images deleted.');
+    }
+}

--- a/src/Console/Commands/DeleteOldImages.php
+++ b/src/Console/Commands/DeleteOldImages.php
@@ -13,9 +13,9 @@ class DeleteOldImages extends Command
     protected $description = 'Delete old images from the storage folder';
 
     public function __construct(
-        #[Config('og-image-generator.storage.disk')] private readonly string $disk,
-        #[Config('og-image-generator.storage.path')] private readonly string $path,
-        #[Config('og-image-generator.storage.lifetime')] private readonly string $lifetime,
+        #[Config('og-image-generator.storage.disk')] private readonly ?string $disk,
+        #[Config('og-image-generator.storage.path')] private readonly ?string $path,
+        #[Config('og-image-generator.storage.lifetime', 90)] private readonly int $lifetime,
     ) {
         parent::__construct();
     }

--- a/src/OgImageGeneratorServiceProvider.php
+++ b/src/OgImageGeneratorServiceProvider.php
@@ -2,7 +2,9 @@
 
 namespace Paulund\OgImageGenerator;
 
+use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Support\ServiceProvider;
+use Paulund\OgImageGenerator\Console\Commands\DeleteOldImages;
 
 class OgImageGeneratorServiceProvider extends ServiceProvider
 {
@@ -16,5 +18,16 @@ class OgImageGeneratorServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/../config' => config_path(),
         ], 'paulund/og-image-generator');
+
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                DeleteOldImages::class,
+            ]);
+        }
+
+        $this->app->booted(function () {
+            $schedule = $this->app->make(Schedule::class);
+            $schedule->command('og-image:delete-old-images')->daily();
+        });
     }
 }

--- a/testbench.yaml
+++ b/testbench.yaml
@@ -1,5 +1,5 @@
 providers:
-  # - Workbench\App\Providers\WorkbenchServiceProvider
+  - Paulund\OgImageGenerator\OgImageGeneratorServiceProvider
 
 migrations:
   - workbench/database/migrations

--- a/tests/Feature/Console/Commands/DeleteOldImagesTest.php
+++ b/tests/Feature/Console/Commands/DeleteOldImagesTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Storage;
+
+it('deletes images older than 90 days', function () {
+    Storage::fake('local');
+
+    $path = config('og-image-generator.storage.path');
+    $oldFile = $path.'/old_image.png';
+    $newFile = $path.'/new_image.png';
+
+    Storage::disk('local')->put($oldFile, 'content');
+    touch(Storage::disk('local')->path($oldFile), Carbon::now()->subDays(91)->timestamp);
+    Storage::disk('local')->put($newFile, 'content');
+    touch(Storage::disk('local')->path($newFile), Carbon::now()->subDays(1)->timestamp);
+
+    $this->artisan('og-image:delete-old-images')->assertExitCode(0);
+
+    Storage::disk('local')->assertMissing($oldFile);
+    Storage::disk('local')->assertExists($newFile);
+});
+
+it('does not delete images newer than 90 days', function () {
+    Storage::fake('local');
+
+    $path = config('og-image-generator.storage.path');
+    $newFile = $path.'/new_image.png';
+
+    Storage::disk('local')->put($newFile, 'content');
+
+    Carbon::setTestNow(Carbon::now()->subDays(1));
+    touch(Storage::disk('local')->path($newFile));
+    Carbon::setTestNow();
+
+    $this->artisan('og-image:delete-old-images')->assertExitCode(0);
+
+    Storage::disk('local')->assertExists($newFile);
+});
+
+it('handles empty storage path gracefully', function () {
+    Storage::fake('local');
+
+    $this->artisan('og-image:delete-old-images')->assertExitCode(0);
+
+    $this->assertTrue(true); // Ensure no exceptions are thrown
+});


### PR DESCRIPTION
## Delete Old Images
This change will add a command to the package that will delete any images that are older than 90 days.

We also attach the command to the scheduler to run every day.

This change will help tidy up your server local temp files created by the OG image generator.

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] Tests have been added or updated
- [X] Documentation has been added or updated
- [X] Code has been tested on external projects
