### PR TITLE
Allow users to change the view file for the og image generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,31 @@ But you can configure the package by publishing the config file, which will allo
 - Storage disk - default is local
 - Storage path - default is public/og-images
 
+### Config Styling
+By default OG Image Generator comes with tailwinds css installed on the page and you can customise the styling of
+the image by changing the tailwind classes in the config file.
+
+```php
+'styling' => [
+    'background' => 'bg-gray-900',
+    'text' => 'text-white',
+],
+```
+
+## Customise The View
+
+If you'd like you use your own blade view file then you can change the view config in the config file.
+
+```php
+'view' => env('OG_IMAGE_GENERATOR_VIEW', 'paulund/og-image-generator::image'),
+```
+
+Or you can change the view in the `.env` file.
+
+```bash
+OG_IMAGE_GENERATOR_VIEW=your-view-file
+```
+
 ## Delete Old Images
 
 There is a command that you can run to delete all the old images that have been created by the package.

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,9 @@
         }
     },
     "scripts": {
+        "post-update-cmd": [
+            "@php artisan vendor:publish --provider=\"Paulund\\OgImageGenerator\\OgImageGeneratorServiceProvider\" --force"
+        ],
         "serve": [
             "Composer\\Config::disableProcessTimeout",
             "@build",

--- a/composer.json
+++ b/composer.json
@@ -45,9 +45,6 @@
         }
     },
     "scripts": {
-        "post-update-cmd": [
-            "@php artisan vendor:publish --provider=\"Paulund\\OgImageGenerator\\OgImageGeneratorServiceProvider\" --force"
-        ],
         "serve": [
             "Composer\\Config::disableProcessTimeout",
             "@build",

--- a/config/og-image-generator.php
+++ b/config/og-image-generator.php
@@ -18,6 +18,11 @@ return [
     ],
 
     /**
+     * The view to use for the image
+     */
+    'view' => env('OG_IMAGE_GENERATOR_VIEW', 'paulund/og-image-generator::image'),
+
+    /**
      * CSS classes for the image
      */
     'styling' => [

--- a/src/Http/Controllers/OgImageController.php
+++ b/src/Http/Controllers/OgImageController.php
@@ -2,6 +2,7 @@
 
 namespace Paulund\OgImageGenerator\Http\Controllers;
 
+use Illuminate\Container\Attributes\Config;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Storage;
@@ -11,6 +12,11 @@ use Paulund\OgImageGenerator\Actions\HtmlToPng;
 class OgImageController extends Controller
 {
     private bool $showBlade = false;
+
+    public function __construct(
+        #[Config('og-image-generator.styling')] protected array $styling,
+        #[Config('og-image-generator.view')] protected string $view,
+    ) {}
 
     public function __invoke(Request $request): \Illuminate\Http\Response
     {
@@ -28,9 +34,9 @@ class OgImageController extends Controller
             return $this->returnImage($this->getImage($slugTitle));
         }
 
-        $html = view('paulund/og-image-generator::image', [
+        $html = view($this->view, [
             'title' => request('title', 'Title'),
-            'styling' => config('og-image-generator.styling'),
+            'styling' => $this->styling,
         ])->render();
 
         if ($this->showBlade) {

--- a/src/Http/Controllers/OgImageController.php
+++ b/src/Http/Controllers/OgImageController.php
@@ -2,7 +2,6 @@
 
 namespace Paulund\OgImageGenerator\Http\Controllers;
 
-use Illuminate\Container\Attributes\Config;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Storage;
@@ -13,10 +12,18 @@ class OgImageController extends Controller
 {
     private bool $showBlade = false;
 
-    public function __construct(
-        #[Config('og-image-generator.styling')] protected array $styling,
-        #[Config('og-image-generator.view')] protected string $view,
-    ) {}
+    private array $styling;
+
+    private string $view;
+
+    private string $disk;
+
+    public function __construct()
+    {
+        $this->styling = \config('og-image-generator.styling');
+        $this->view = \config('og-image-generator.view');
+        $this->disk = \config('og-image-generator.storage.disk');
+    }
 
     public function __invoke(Request $request): \Illuminate\Http\Response
     {
@@ -67,16 +74,16 @@ class OgImageController extends Controller
 
     private function hasImage(string $slugTitle): bool
     {
-        return Storage::disk(config('og-image-generator.storage.disk'))->exists($this->getFilePath($slugTitle));
+        return Storage::disk($this->disk)->exists($this->getFilePath($slugTitle));
     }
 
     private function getImage(string $slugTitle): string
     {
-        return Storage::disk(config('og-image-generator.storage.disk'))->get($this->getFilePath($slugTitle));
+        return Storage::disk($this->disk)->get($this->getFilePath($slugTitle));
     }
 
     private function saveImage(string $slugTitle, string $image): void
     {
-        Storage::disk(config('og-image-generator.storage.disk'))->put($this->getFilePath($slugTitle), $image);
+        Storage::disk($this->disk)->put($this->getFilePath($slugTitle), $image);
     }
 }

--- a/tests/Feature/OgImageTest.php
+++ b/tests/Feature/OgImageTest.php
@@ -1,9 +1,11 @@
 <?php
 
+use Illuminate\Support\Facades\Config;
 use Paulund\OgImageGenerator\Actions\HtmlToPng;
 
 beforeEach(function () {
     \Illuminate\Support\Facades\Storage::fake('local');
+    Config::set('og-image-generator', require __DIR__.'/../../config/og-image-generator.php');
 });
 
 test('the og image route returns successful', function () {


### PR DESCRIPTION
Add a new config to change the view file used to generate the images.

There is a change to the dependency injection to the controller and therefore we need a config publish.

```
php artisan vendor:publish --provider="Paulund\OgImageGenerator\OgImageGeneratorServiceProvider" --force
```

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] Tests have been added or updated
- [X] Documentation has been added or updated
- [X] Code has been tested on external projects
